### PR TITLE
fix(:wrench:): changed the env variable name of GITHUB_TOKEN into SEMANTIC_RELEASE_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
       run: npm ci
     - name: Release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
       run: npx semantic-release


### PR DESCRIPTION
this change is made to overcome the branch protection feature of the GitHub blocking `semantic-release`'s commit(making release related assets)